### PR TITLE
fix-alsort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "alsort"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "camino",

--- a/alsort/Cargo.toml
+++ b/alsort/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alsort"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 
 [dependencies]

--- a/alsort/src/main.rs
+++ b/alsort/src/main.rs
@@ -137,7 +137,7 @@ mod test {
         let temp = Utf8TempDir::new().unwrap();
         temp.child("a_file.txt").touch().unwrap();
         temp.child("abc").create_dir_all().unwrap();
-        let file_under_test = temp.path().join("abc");
+        let file_under_test = temp.path().canonicalize_utf8().unwrap().join("abc");
 
         assert!(file_under_test.exists());
 
@@ -145,7 +145,7 @@ mod test {
             !process(
                 &file_under_test,
                 &Cli {
-                    root: temp.path().to_path_buf(),
+                    root: temp.path().canonicalize_utf8().unwrap().to_path_buf(),
                     verbose: false,
                     group: true,
                     files: vec![],


### PR DESCRIPTION
improve usage info

fix bug: alsort failed if target dirs did not exist

fix tests for macos /tmp